### PR TITLE
Optimize tag location to follow Google's instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ You can use default code on all pages or you can specify unique tag for specific
 1. Install the plugin via the October CMS backend.
 2. Add your site configuration details to the Google Tag Manager Plugin configuration page. (Under the 'Misc' section of the System Settings page in the Backend).
 3. Add the Google Tag Manager Component to your master layout.
-4. Add ```{% component 'gtmCode' %}``` to the content of the default layout so that it appears immediately after the opening ```<body>``` tag.
-5. Save the file.
+4. Add ```{% component 'gtmCode' %}``` to the ```<head>``` of the default layout, preferably as close to the opening ```<head>``` tag as possible, but below any dataLayer declarations.
+5. Add ```{% placeholder 'gtm' %}``` to the content of the default layout so that it appears immediately after the opening ```<body>``` tag.
+6. Save the file.
 
 You can also add the component to the file manually and/or override ```container_id``` from your settings.  For Example:
 
@@ -25,13 +26,14 @@ You can also add the component to the file manually and/or override ```container
 		<title>{{ this.page.title }}</title>
 		<meta name="author" content="October CMS">
     	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+    	{% component 'gtmCode' %}
     	{% styles %}
     	<link href="{{ [
     	    'assets/css/theme.css'
     	]|theme }}" rel="stylesheet">
 	</head>
 	<body>
-        {% component 'gtmCode' %}
+        {% placeholder 'gtm' %}
         
  		<header>
  			<h1>Header</h1>

--- a/components/tagmanager/default.htm
+++ b/components/tagmanager/default.htm
@@ -1,6 +1,11 @@
-<!-- Google Tag Manager -->
+{% put gtm %}
+<!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="//www.googletagmanager.com/ns.html?id={{ __SELF__.containerId }}"
                   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+{% endput %}
+
+<!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=


### PR DESCRIPTION
Google's instruction says;

> Place the <script> code snippet in the <head> of your web page's HTML output, preferably as close to the opening <head> tag as possible, but below any dataLayer declarations.
> Place the <noscript> code snippet immediately after the <body> tag in your HTML output.

This PR let the component to insert `<script>` and `<noscript>` to the separate place in the output HTML as Google instructs.

It seems current version of OctoberCMS (437) does not properly render `{% put %}` if it is before `{% component %}`. So, I changed the instruction in README.md to put `{% component %}` right after `<meta>`.

I confirmed this worked with the latest version of OctoberCMS (437).